### PR TITLE
Add Coalesce functionality

### DIFF
--- a/gog.go
+++ b/gog.go
@@ -16,6 +16,24 @@ func If[T any](cond bool, vtrue, vfalse T) T {
 	return vfalse
 }
 
+// Coalesce returns the first non-zero value from listed arguments.
+// Returns the zero value of the type parameter if no arguments are given or all are the zero value.
+// Useful when you want to initialize a variable to the first non-zero value from a list of fallback values.
+//
+// For example:
+//
+//	hostVal := Coalesce(hostName, os.Getenv("HOST"), "localhost")
+func Coalesce[T comparable](values ...T) T {
+	var v, zero T
+	for _, v = range values {
+		if v != zero {
+			break
+		}
+	}
+
+	return v
+}
+
 // Ptr returns a pointer to the passed value.
 //
 // Useful when you have a value and need a pointer, e.g.:

--- a/gog.go
+++ b/gog.go
@@ -24,14 +24,14 @@ func If[T any](cond bool, vtrue, vfalse T) T {
 //
 //	hostVal := Coalesce(hostName, os.Getenv("HOST"), "localhost")
 func Coalesce[T comparable](values ...T) T {
-	var v, zero T
-	for _, v = range values {
+	var zero T
+	for _, v := range values {
 		if v != zero {
-			break
+			return v
 		}
 	}
 
-	return v
+	return zero
 }
 
 // Ptr returns a pointer to the passed value.

--- a/gog_test.go
+++ b/gog_test.go
@@ -31,6 +31,21 @@ func TestIf(t *testing.T) {
 	}
 }
 
+func TestCoalesce(t *testing.T) {
+	if "" != Coalesce("", "", "") {
+		t.Errorf("All args are zero value")
+	}
+	if "stopHere" != Coalesce("", "stopHere", "") {
+		t.Errorf("One arg is not zero value")
+	}
+	if 123 != Coalesce(0, 0, 123, 432) {
+		t.Errorf("More args are not zero value")
+	}
+	if true != Coalesce(false, false, true) {
+		t.Errorf("Bool args are not zero value")
+	}
+}
+
 func TestPtr(t *testing.T) {
 	s := "a"
 	sp := Ptr(s)


### PR DESCRIPTION
This is done in accordance to our [previous discussion](https://github.com/icza/gog/pull/1)
- it works in go 1.18, according to the `go.mod`
- it's no longer based on reflection
- there will always be a single type accepted for all the list of args, as well as the return type
- all tests have passed successfuly